### PR TITLE
Change gitter link to matrix.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 ![Angular Dart](https://raw.githubusercontent.com/dart-lang/angular/master/doc/angulardart-logo.png)
 
 [![Build Status](https://travis-ci.org/dart-lang/angular.svg?branch=master)](https://travis-ci.org/dart-lang/angular)
-[![Gitter](https://img.shields.io/gitter/room/dart-lang/angular.svg)][Gitter chat room]
+[![Gitter](https://img.shields.io/gitter/room/dart-lang/angular.svg)][gitter chat room]
 
 The _AngularDart_ packages power some of Google's most critical applications.
 It's built on [Dart] and is used by [Google Ads], [Google AdSense],
 [Google Fiber], [Google Play Console] and many more projects.
 
-[Google Play Console]: https://play.google.com/console
-[Google AdSense]: https://www.google.com/adsense
-[Google Ads]: https://ads.google.com/
-[Google Fiber]: https://fiber.google.com/
-[Dart]: https://dart.dev/
+[google play console]: https://play.google.com/console
+[google adsense]: https://www.google.com/adsense
+[google ads]: https://ads.google.com/
+[google fiber]: https://fiber.google.com/
+[dart]: https://dart.dev/
 
 **IMPORTANT:** read the
 [announcement](https://groups.google.com/a/dartlang.org/g/announce/c/Kz84KNBcf3U)
@@ -19,15 +19,15 @@ about how we plan to update and maintain these packages going forward!
 
 ## Packages
 
-| Source code                  | Published Version                                                                                                  |
-|------------------------------|:------------------------------------------------------------------------------------------------------------------:|
-| [angular]                    | [![Pub Package](https://img.shields.io/pub/v/angular.svg)](https://pub.dev/packages/angular)                       |
-| [angular_forms]              | [![Pub Package](https://img.shields.io/pub/v/angular_forms.svg)](https://pub.dev/packages/angular_forms)           |
-| [angular_router]             | [![Pub Package](https://img.shields.io/pub/v/angular_router.svg)](https://pub.dev/packages/angular_router)         |
-| [angular_test]               | [![Pub Package](https://img.shields.io/pub/v/angular_test.svg)](https://pub.dev/packages/angular_test)             |
+| Source code                  |                                                 Published Version                                                  |
+| ---------------------------- | :----------------------------------------------------------------------------------------------------------------: |
+| [angular]                    |            [![Pub Package](https://img.shields.io/pub/v/angular.svg)](https://pub.dev/packages/angular)            |
+| [angular_forms]              |      [![Pub Package](https://img.shields.io/pub/v/angular_forms.svg)](https://pub.dev/packages/angular_forms)      |
+| [angular_router]             |     [![Pub Package](https://img.shields.io/pub/v/angular_router.svg)](https://pub.dev/packages/angular_router)     |
+| [angular_test]               |       [![Pub Package](https://img.shields.io/pub/v/angular_test.svg)](https://pub.dev/packages/angular_test)       |
 | [angular_components]&dagger; | [![Pub Package](https://img.shields.io/pub/v/angular_components.svg)](https://pub.dev/packages/angular_components) |
-| [angular_ast]&ddagger;       | [![Pub Package](https://img.shields.io/pub/v/angular_ast.svg)](https://pub.dev/packages/angular_ast)               |
-| [angular_compiler]&ddagger;  | [![Pub Package](https://img.shields.io/pub/v/angular_compiler.svg)](https://pub.dev/packages/angular_compiler)     |
+| [angular_ast]&ddagger;       |        [![Pub Package](https://img.shields.io/pub/v/angular_ast.svg)](https://pub.dev/packages/angular_ast)        |
+| [angular_compiler]&ddagger;  |   [![Pub Package](https://img.shields.io/pub/v/angular_compiler.svg)](https://pub.dev/packages/angular_compiler)   |
 
 &dagger; _`angular_components` source is in another [repository](https://github.com/dart-lang/angular_components)._
 
@@ -45,4 +45,4 @@ about how we plan to update and maintain these packages going forward!
 
 Join the [Gitter chat room] to ask questions.
 
-[Gitter chat room]: https://gitter.im/dart-lang/angular
+[gitter chat room]: https://matrix.to/#/#dart-lang_angular:gitter.im

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 ![Angular Dart](https://raw.githubusercontent.com/dart-lang/angular/master/doc/angulardart-logo.png)
 
 [![Build Status](https://travis-ci.org/dart-lang/angular.svg?branch=master)](https://travis-ci.org/dart-lang/angular)
-[![Gitter](https://img.shields.io/gitter/room/dart-lang/angular.svg)][gitter chat room]
+[![Gitter](https://img.shields.io/gitter/room/dart-lang/angular.svg)][Gitter chat room]
 
 The _AngularDart_ packages power some of Google's most critical applications.
 It's built on [Dart] and is used by [Google Ads], [Google AdSense],
 [Google Fiber], [Google Play Console] and many more projects.
 
-[google play console]: https://play.google.com/console
-[google adsense]: https://www.google.com/adsense
-[google ads]: https://ads.google.com/
-[google fiber]: https://fiber.google.com/
-[dart]: https://dart.dev/
+[Google Play Console]: https://play.google.com/console
+[Google AdSense]: https://www.google.com/adsense
+[Google Ads]: https://ads.google.com/
+[Google Fiber]: https://fiber.google.com/
+[Dart]: https://dart.dev/
 
 **IMPORTANT:** read the
 [announcement](https://groups.google.com/a/dartlang.org/g/announce/c/Kz84KNBcf3U)
@@ -19,15 +19,15 @@ about how we plan to update and maintain these packages going forward!
 
 ## Packages
 
-| Source code                  |                                                 Published Version                                                  |
-| ---------------------------- | :----------------------------------------------------------------------------------------------------------------: |
-| [angular]                    |            [![Pub Package](https://img.shields.io/pub/v/angular.svg)](https://pub.dev/packages/angular)            |
-| [angular_forms]              |      [![Pub Package](https://img.shields.io/pub/v/angular_forms.svg)](https://pub.dev/packages/angular_forms)      |
-| [angular_router]             |     [![Pub Package](https://img.shields.io/pub/v/angular_router.svg)](https://pub.dev/packages/angular_router)     |
-| [angular_test]               |       [![Pub Package](https://img.shields.io/pub/v/angular_test.svg)](https://pub.dev/packages/angular_test)       |
+| Source code                  | Published Version                                                                                                  |
+|------------------------------|:------------------------------------------------------------------------------------------------------------------:|
+| [angular]                    | [![Pub Package](https://img.shields.io/pub/v/angular.svg)](https://pub.dev/packages/angular)                       |
+| [angular_forms]              | [![Pub Package](https://img.shields.io/pub/v/angular_forms.svg)](https://pub.dev/packages/angular_forms)           |
+| [angular_router]             | [![Pub Package](https://img.shields.io/pub/v/angular_router.svg)](https://pub.dev/packages/angular_router)         |
+| [angular_test]               | [![Pub Package](https://img.shields.io/pub/v/angular_test.svg)](https://pub.dev/packages/angular_test)             |
 | [angular_components]&dagger; | [![Pub Package](https://img.shields.io/pub/v/angular_components.svg)](https://pub.dev/packages/angular_components) |
-| [angular_ast]&ddagger;       |        [![Pub Package](https://img.shields.io/pub/v/angular_ast.svg)](https://pub.dev/packages/angular_ast)        |
-| [angular_compiler]&ddagger;  |   [![Pub Package](https://img.shields.io/pub/v/angular_compiler.svg)](https://pub.dev/packages/angular_compiler)   |
+| [angular_ast]&ddagger;       | [![Pub Package](https://img.shields.io/pub/v/angular_ast.svg)](https://pub.dev/packages/angular_ast)               |
+| [angular_compiler]&ddagger;  | [![Pub Package](https://img.shields.io/pub/v/angular_compiler.svg)](https://pub.dev/packages/angular_compiler)     |
 
 &dagger; _`angular_components` source is in another [repository](https://github.com/dart-lang/angular_components)._
 
@@ -45,4 +45,4 @@ about how we plan to update and maintain these packages going forward!
 
 Join the [Gitter chat room] to ask questions.
 
-[gitter chat room]: https://matrix.to/#/#dart-lang_angular:gitter.im
+[Gitter chat room]: https://matrix.to/#/#dart-lang_angular:gitter.im


### PR DESCRIPTION
Gitter has moved to matrix.org - [source](https://matrix.org/blog/2020/12/07/gitter-now-speaks-matrix)
Providing a better user experience.

Also Gitter iOS and Android App are deprecated and will be remove from store to be replaced by Element app (or [others](https://matrix.org/clients/)) - [source](https://gitlab.com/gitterHQ/webapp/-/issues/2281)